### PR TITLE
BUG: Use decodeIfPresent to decode optionals when reporting is in place

### DIFF
--- a/Sources/SafeDecoding/Macros/Macros/SafeDecodingMacro.swift
+++ b/Sources/SafeDecoding/Macros/Macros/SafeDecodingMacro.swift
@@ -229,7 +229,7 @@ private extension SafeDecodingMacro {
         return if let reporter {
             """
             do {
-                self.\(pattern.identifier) = try container.decode((\(elementType)).self, forKey: .\(pattern.identifier))
+                self.\(pattern.identifier) = try container.decodeIfPresent((\(elementType)).self, forKey: .\(pattern.identifier))
             } catch {
                 self.\(pattern.identifier) = nil
                 \(reporter).report(error: error, of: "\(raw: pattern.identifier.description)", decoding: (Optional<\(elementType)>).self, in: (\(container)).self)


### PR DESCRIPTION
- adopt `decodeIfPresent` to decode optionals when error reporting is in place