### PR TITLE
Fix coding keys being used for encoding plain enum cases

### DIFF
--- a/Sources/SafeDecoding/Macros/Macros/Attached/EnumSafeDecodingMacro.swift
+++ b/Sources/SafeDecoding/Macros/Macros/Attached/EnumSafeDecodingMacro.swift
@@ -487,7 +487,7 @@ private extension EnumSafeDecodingMacro {
                                 }
                             } else {
                                 SwitchCaseSyntax("case .\(raw: elementName):") {
-                                    CodeBlockItemListSyntax("var container = encoder.container(keyedBy: \(raw: elementCodingKeysName).self)")
+                                    CodeBlockItemListSyntax("var container = encoder.container(keyedBy: \(raw: rootCodingKeysName).self)")
                                     CodeBlockItemListSyntax("try container.encode(\(raw: casingKeysName).\(raw: elementName).rawValue, forKey: .\(raw: casingPropertyName))")
                                 }
                             }


### PR DESCRIPTION
- Use root coding keys type instead of type-specific coding keys