### PR TITLE
Add optional decoding

### DIFF
--- a/Sources/SafeDecoding/ExampleClient/main.swift
+++ b/Sources/SafeDecoding/ExampleClient/main.swift
@@ -66,12 +66,27 @@ struct ModelStandardExample {
     let constantInferred = 0
 }
 
+enum FeatureFlag {
+    case someFeature
+}
+
+struct Features {
+    func isEnabled(_ feature: FeatureFlag) -> Bool {
+        true
+    }
+
+    private init() { }
+
+    static let shared = Features()
+}
+
 // Expand macro to see code generated for extended usage of @SafeDecoding
 // using the reporter, as well as @RetryDecoding, @FallbackDecoding and @IgnoreSafeDecoding
 // macros as decorators
 
 @SafeDecoding(reporter: SafeDecodingErrorReporter.shared)
 struct ModelFullExample {
+    let double: Double
     @RetryDecoding(String.self, map: { Int($0, radix: 10) })
     @RetryDecoding(Double.self, map: { Int($0) })
     let integer: Int
@@ -81,6 +96,7 @@ struct ModelFullExample {
     @FallbackDecoding(UUID().uuidString)
     let string: String
     let dictionary: [String: Int]
+    @OptionalDecoding(Features.shared.isEnabled(.someFeature))
     @FallbackDecoding(0)
     @RetryDecoding(String.self, map: { Int($0, radix: 10) })
     @RetryDecoding(Double.self, map: { Int($0) })

--- a/Sources/SafeDecoding/Macros/Macros/Peers/OptionalDecodingMacro.swift
+++ b/Sources/SafeDecoding/Macros/Macros/Peers/OptionalDecodingMacro.swift
@@ -1,0 +1,12 @@
+import SwiftSyntax
+import SwiftSyntaxMacros
+
+public enum OptionalDecodingMacro: PeerMacro {
+    public static func expansion(
+        of node: AttributeSyntax,
+        providingPeersOf declaration: some DeclSyntaxProtocol,
+        in context: some MacroExpansionContext
+    ) throws -> [DeclSyntax] {
+        return [ ]
+    }
+}

--- a/Sources/SafeDecoding/Macros/PlugIn.swift
+++ b/Sources/SafeDecoding/Macros/PlugIn.swift
@@ -11,6 +11,7 @@ struct SafeDecodingPlugin: CompilerPlugin {
         IgnoreSafeDecodingMacro.self,
         RetryDecodingMacro.self,
         FallbackDecodingMacro.self,
-        CaseNameDecodingMacro.self
+        CaseNameDecodingMacro.self,
+        OptionalDecodingMacro.self
     ]
 }

--- a/Sources/SafeDecoding/PlugIn/OptionalDecoding.swift
+++ b/Sources/SafeDecoding/PlugIn/OptionalDecoding.swift
@@ -1,0 +1,19 @@
+/**
+ The ``OptionalDecoding(_:)`` macros allow for optional decoding
+ to be performed in class/struct properties.
+ This is only applicable to optional types, where:
+ - if the condition evaluates to `true`, standard decoding rules apply
+ - if the condition evaluates to `false`, the property will directly be set to `nil`
+ */
+
+@attached(peer)
+public macro OptionalDecoding(_ condition: @escaping () -> Bool) = #externalMacro(
+    module: "SafeDecodingMacros",
+    type: "OptionalDecodingMacro"
+)
+
+@attached(peer)
+public macro OptionalDecoding(_ condition: Bool) = #externalMacro(
+    module: "SafeDecodingMacros",
+    type: "OptionalDecodingMacro"
+)


### PR DESCRIPTION
- Added @OptionalDecoding, allowing for (optional) properties to be conditionally excluded from decoding
- Accounted for the presence of @OptionalDecoding for classes/structs/actors
- Added unit tests
- Added example to main.swift