### PR TITLE
Coding key name overrides

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-syntax.git",
       "state" : {
-        "revision" : "74203046135342e4a4a627476dd6caf8b28fe11b",
-        "version" : "509.0.0"
+        "revision" : "f99ae8aa18f0cf0d53481901f88a0991dc3bd4a2",
+        "version" : "601.0.1"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -17,7 +17,7 @@ var package = Package(
         // Depend on the Swift 5.9 release of SwiftSyntax
         .package(
             url: "https://github.com/apple/swift-syntax.git",
-            from: "509.0.0"
+            from: "601.0.0"
         )
     ]
 )

--- a/Sources/SafeDecoding/ExampleClient/main.swift
+++ b/Sources/SafeDecoding/ExampleClient/main.swift
@@ -44,14 +44,14 @@ class SafeDecodingErrorReporter: SafeDecodingReporter {
     static let shared = SafeDecodingErrorReporter()
 }
 
-@SafeDecoding(reporter: SafeDecodingErrorReporter.shared)
-struct SubModel {
+@SafeDecoding(reporter: SafeDecodingErrorReporter.shared, shouldImplementEncoding: true)
+struct SubModel: Codable {
     let strings: Array<String>
 }
 
 // Expand macro to see code generated for the base usage of @SafeDecoding
 
-@SafeDecoding(reporter: SafeDecodingErrorReporter.shared)
+@SafeDecoding(reporter: SafeDecodingErrorReporter.shared, shouldImplementEncoding: true)
 struct ModelStandardExample {
     let integer: Int
     let integerArray: [Int]
@@ -84,8 +84,9 @@ struct Features {
 // using the reporter, as well as @RetryDecoding, @FallbackDecoding and @IgnoreSafeDecoding
 // macros as decorators
 
-@SafeDecoding(reporter: SafeDecodingErrorReporter.shared)
+@SafeDecoding(reporter: SafeDecodingErrorReporter.shared, shouldImplementEncoding: true)
 struct ModelFullExample {
+    @PropertyNameDecoding("custon-double")
     let double: Double
     @RetryDecoding(String.self, map: { Int($0, radix: 10) })
     @RetryDecoding(Double.self, map: { Int($0) })

--- a/Sources/SafeDecoding/Macros/Macros/Attached/EnumSafeDecodingMacro.swift
+++ b/Sources/SafeDecoding/Macros/Macros/Attached/EnumSafeDecodingMacro.swift
@@ -40,9 +40,8 @@ extension EnumSafeDecodingMacro: ExtensionMacro {
         let cases = enumDecl
             .memberBlock
             .members
-            .compactMap({
-                $0
-                    .as(MemberBlockItemSyntax.self)?
+            .compactMap({ member in
+                member
                     .decl
                     .as(EnumCaseDeclSyntax.self)
             })
@@ -177,13 +176,10 @@ private extension EnumSafeDecodingMacro {
                         let parameters = element
                             .parameterClause?
                             .parameters
-                            .map({
-                                $0.as(EnumCaseParameterSyntax.self)
-                            })
                     {
                         try EnumDeclSyntax("private enum \(raw: rootCodingKeysName)_\(raw: elementName): String, CodingKey") {
                             for (index, parameter) in parameters.enumerated() {
-                                let parameterName = parameter?.firstName?.text ?? "_\(index)"
+                                let parameterName = parameter.firstName?.text ?? "_\(index)"
                                 try EnumCaseDeclSyntax("case \(raw: parameterName)")
                             }
                         }
@@ -202,7 +198,7 @@ private extension EnumSafeDecodingMacro {
                         rootCodingKeysName: rootCodingKeysName
                     )
 
-                    for (index, parameter) in (element.parameterClause?.parameters.compactMap({ $0.as(EnumCaseParameterSyntax.self) }) ?? []).enumerated() {
+                    for (index, parameter) in (element.parameterClause?.parameters ?? []).enumerated() {
                         try decode(
                             parameter: parameter,
                             at: index,
@@ -302,11 +298,10 @@ private extension EnumSafeDecodingMacro {
                         let parameters = element
                             .parameterClause?
                             .parameters
-                            .map({ $0.as(EnumCaseParameterSyntax.self) })
                     {
                         try EnumDeclSyntax("private enum \(raw: rootCodingKeysName)_\(raw: element.name.text): String, CodingKey") {
                             for (index, parameter) in parameters.enumerated() {
-                                try EnumCaseDeclSyntax("case \(raw: parameter?.firstName?.text ?? "_\(index)")")
+                                try EnumCaseDeclSyntax("case \(raw: parameter.firstName?.text ?? "_\(index)")")
                             }
                         }
                     }
@@ -321,7 +316,7 @@ private extension EnumSafeDecodingMacro {
                         rootCodingKeysName: rootCodingKeysName
                     )
 
-                    for (index, parameter) in (element.parameterClause?.parameters.compactMap({ $0.as(EnumCaseParameterSyntax.self) }) ?? []).enumerated() {
+                    for (index, parameter) in (element.parameterClause?.parameters ?? []).enumerated() {
                         try decode(
                             parameter: parameter,
                             at: index,
@@ -354,12 +349,6 @@ private extension EnumSafeDecodingMacro {
         element: EnumCaseElementListSyntax.Element,
         rootCodingKeysName: String
     ) throws -> MemberBlockItemListSyntax {
-        guard
-            let element = element.as(EnumCaseElementSyntax.self)
-        else {
-            throw EnumSafeDecodingMacro.Errors.unexpectedError
-        }
-
         let caseName = element.name.text
         let parameters = element.parameterClause?.parameters.map { $0 } ?? []
 
@@ -824,16 +813,14 @@ private extension EnumSafeDecodingMacro {
             .as(LabeledExprListSyntax.self)?
             .compactMap({ argument -> String? in
                 guard
-                    let labeledExpression = argument.as(LabeledExprSyntax.self),
-                    labeledExpression.label?.text == "decodingStrategy",
-                    let expression = labeledExpression
+                    argument.label?.text == "decodingStrategy",
+                    let expression = argument
                         .expression
                         .as(FunctionCallExprSyntax.self),
                     expression
                         .calledExpression
                         .as(MemberAccessExprSyntax.self)?
                         .declName
-                        .as(DeclReferenceExprSyntax.self)?
                         .baseName
                         .text == "caseByObjectProperty",
                     let caseName = expression
@@ -867,9 +854,8 @@ private extension EnumSafeDecodingMacro {
             .as(LabeledExprListSyntax.self)?
             .compactMap({ argument -> Bool? in
                 if
-                    let labeledExpression = argument.as(LabeledExprSyntax.self),
-                    labeledExpression.label?.text == "shouldImplementEncoding",
-                    labeledExpression
+                    argument.label?.text == "shouldImplementEncoding",
+                    argument
                         .expression
                         .as(BooleanLiteralExprSyntax.self)?
                         .literal

--- a/Sources/SafeDecoding/Macros/Macros/Attached/Model/Retry.swift
+++ b/Sources/SafeDecoding/Macros/Macros/Attached/Model/Retry.swift
@@ -18,8 +18,8 @@ struct Retry {
             attribute.attributeName.as(IdentifierTypeSyntax.self)?.name.text == "RetryDecoding",
             let arguments = attribute.arguments?.as(LabeledExprListSyntax.self),
             arguments.count == 2,
-            let type = arguments.first?.as(LabeledExprSyntax.self)?.expression,
-            let mapper = arguments.last?.as(LabeledExprSyntax.self)?.expression
+            let type = arguments.first?.expression,
+            let mapper = arguments.last?.expression
         else {
             return nil
         }

--- a/Sources/SafeDecoding/Macros/Macros/Peers/PropertyNameDecodingMacro.swift
+++ b/Sources/SafeDecoding/Macros/Macros/Peers/PropertyNameDecodingMacro.swift
@@ -1,0 +1,12 @@
+import SwiftSyntax
+import SwiftSyntaxMacros
+
+public enum PropertyNameDecodingMacro: PeerMacro {
+    public static func expansion(
+        of node: AttributeSyntax,
+        providingPeersOf declaration: some DeclSyntaxProtocol,
+        in context: some MacroExpansionContext
+    ) throws -> [DeclSyntax] {
+        []
+    }
+}

--- a/Sources/SafeDecoding/Macros/Macros/Utils/SyntaxUtils.swift
+++ b/Sources/SafeDecoding/Macros/Macros/Utils/SyntaxUtils.swift
@@ -7,11 +7,8 @@ extension SyntaxUtils {
     static func accessControl(decl: DeclGroupSyntax) -> AccessControl? {
         decl
             .modifiers
-            .compactMap {
-                $0.as(DeclModifierSyntax.self)
-                    .flatMap {
-                        AccessControl(rawValue: $0.name.text)
-                    }
+            .compactMap { (modifier: DeclModifierListSyntax.Element) in
+                AccessControl(rawValue: modifier.name.text)
             }
             .first
     }
@@ -68,10 +65,10 @@ extension SyntaxUtils {
             let type = type.as(IdentifierTypeSyntax.self),
             type.name.text == "Dictionary",
             type.genericArgumentClause?.arguments.count == 2,
-            let keyType = type.genericArgumentClause?.arguments.first?.argument,
-            let valueType = type.genericArgumentClause?.arguments.last?.argument
+            case let .type(keyType) = type.genericArgumentClause?.arguments.first?.argument,
+            case let .type(valueType) = type.genericArgumentClause?.arguments.last?.argument
         {
-            return (keyType, valueType)
+            return (keyType , valueType)
         }
 
         return nil
@@ -84,9 +81,10 @@ extension SyntaxUtils {
         if
             let type = type.as(IdentifierTypeSyntax.self),
             type.name.text == genericTypeName,
-            type.genericArgumentClause?.arguments.count == 1
+            type.genericArgumentClause?.arguments.count == 1,
+            case let .type(genericType) = type.genericArgumentClause?.arguments.first?.argument
         {
-            return type.genericArgumentClause?.arguments.first?.argument
+            return genericType
         }
 
         return nil

--- a/Sources/SafeDecoding/Macros/PlugIn.swift
+++ b/Sources/SafeDecoding/Macros/PlugIn.swift
@@ -12,6 +12,7 @@ struct SafeDecodingPlugin: CompilerPlugin {
         RetryDecodingMacro.self,
         FallbackDecodingMacro.self,
         CaseNameDecodingMacro.self,
-        OptionalDecodingMacro.self
+        OptionalDecodingMacro.self,
+        PropertyNameDecodingMacro.self
     ]
 }

--- a/Sources/SafeDecoding/PlugIn/PropertyNameDecoding.swift
+++ b/Sources/SafeDecoding/PlugIn/PropertyNameDecoding.swift
@@ -1,0 +1,5 @@
+@attached(peer)
+public macro PropertyNameDecoding(_: StaticString) = #externalMacro(
+    module: "SafeDecodingMacros",
+    type: "PropertyNameDecodingMacro"
+)

--- a/Tests/SafeDecodingMacrosTests/ClassOrStructSafeDecodingMacrosTests.swift
+++ b/Tests/SafeDecodingMacrosTests/ClassOrStructSafeDecodingMacrosTests.swift
@@ -11,7 +11,8 @@ private let testMacros: [String: Macro.Type] = [
     "ClassOrStructSafeDecoding": ClassOrStructSafeDecodingMacro.self,
     "RetryDecoding": RetryDecodingMacro.self,
     "FallbackDecoding": FallbackDecodingMacro.self,
-    "OptionalDecoding": OptionalDecodingMacro.self
+    "OptionalDecoding": OptionalDecodingMacro.self,
+    "PropertyNameDecoding": PropertyNameDecodingMacro.self
 ]
 #endif
 
@@ -39,14 +40,14 @@ extension ClassOrStructSafeDecodingMacrosTests {
                 }
 
                 extension Model {
-                    private enum CodingKeys: CodingKey {
+                    private enum CodingKeys: String, CodingKey {
                         case optional
                         case optionalGeneric
                     }
                     init(from decoder: Decoder) throws {
                         let container = try decoder.container(keyedBy: CodingKeys.self)
-                        self.optional = try? container.decode(Int.self, forKey: .optional)
-                        self.optionalGeneric = try? container.decode(Int.self, forKey: .optionalGeneric)
+                        self.optional = (try? container.decode(Int.self, forKey: .optional))
+                        self.optionalGeneric = (try? container.decode(Int.self, forKey: .optionalGeneric))
                     }
                 }
                 """,
@@ -74,7 +75,7 @@ extension ClassOrStructSafeDecodingMacrosTests {
                 }
 
                 extension Model {
-                    private enum CodingKeys: CodingKey {
+                    private enum CodingKeys: String, CodingKey {
                         case set
                     }
                     init(from decoder: Decoder) throws {
@@ -113,7 +114,7 @@ extension ClassOrStructSafeDecodingMacrosTests {
                 }
 
                 extension Model {
-                    private enum CodingKeys: CodingKey {
+                    private enum CodingKeys: String, CodingKey {
                         case array
                         case arrayGeneric
                     }
@@ -154,7 +155,7 @@ extension ClassOrStructSafeDecodingMacrosTests {
                 }
 
                 extension Model {
-                    private enum CodingKeys: CodingKey {
+                    private enum CodingKeys: String, CodingKey {
                         case dictionary
                         case dictionaryGeneric
                     }
@@ -198,7 +199,7 @@ extension ClassOrStructSafeDecodingMacrosTests {
                 }
 
                 extension Model {
-                    private enum CodingKeys: CodingKey {
+                    private enum CodingKeys: String, CodingKey {
                         case optional
                         case optionalGeneric
                     }
@@ -243,7 +244,7 @@ extension ClassOrStructSafeDecodingMacrosTests {
                 }
 
                 extension Model {
-                    private enum CodingKeys: CodingKey {
+                    private enum CodingKeys: String, CodingKey {
                         case set
                     }
                     init(from decoder: Decoder) throws {
@@ -263,7 +264,7 @@ extension ClassOrStructSafeDecodingMacrosTests {
                             self.set = items
                         } catch {
                             self.set = []
-                            reporter.report(error: error, of: "set", decoding: Set<Int> .self, in: (Model).self)
+                            reporter.report(error: error, of: "set", decoding: Set<Int>.self, in: (Model).self)
                         }
                     }
                 }
@@ -294,7 +295,7 @@ extension ClassOrStructSafeDecodingMacrosTests {
                 }
 
                 extension Model {
-                    private enum CodingKeys: CodingKey {
+                    private enum CodingKeys: String, CodingKey {
                         case array
                         case arrayGeneric
                     }
@@ -363,7 +364,7 @@ extension ClassOrStructSafeDecodingMacrosTests {
                 }
 
                 extension Model {
-                    private enum CodingKeys: CodingKey {
+                    private enum CodingKeys: String, CodingKey {
                         case dictionary
                         case dictionaryGeneric
                     }
@@ -433,7 +434,7 @@ extension ClassOrStructSafeDecodingMacrosTests {
                 }
 
                 extension Model {
-                    private enum CodingKeys: CodingKey {
+                    private enum CodingKeys: String, CodingKey {
                     }
                     init(from decoder: Decoder) throws {
                     }
@@ -465,7 +466,7 @@ extension ClassOrStructSafeDecodingMacrosTests {
                 }
 
                 extension Model {
-                    private enum CodingKeys: CodingKey {
+                    private enum CodingKeys: String, CodingKey {
                     }
                     init(from decoder: Decoder) throws {
                     }
@@ -500,7 +501,7 @@ extension ClassOrStructSafeDecodingMacrosTests {
                 }
 
                 extension Model {
-                    private enum CodingKeys: CodingKey {
+                    private enum CodingKeys: String, CodingKey {
                     }
                     init(from decoder: Decoder) throws {
                     }
@@ -530,7 +531,7 @@ extension ClassOrStructSafeDecodingMacrosTests {
                 }
 
                 extension Model {
-                    private enum CodingKeys: CodingKey {
+                    private enum CodingKeys: String, CodingKey {
                     }
                     internal init(from decoder: Decoder) throws {
                     }
@@ -560,7 +561,7 @@ extension ClassOrStructSafeDecodingMacrosTests {
                 }
 
                 extension Model {
-                    private enum CodingKeys: CodingKey {
+                    private enum CodingKeys: String, CodingKey {
                     }
                     package init(from decoder: Decoder) throws {
                     }
@@ -590,7 +591,7 @@ extension ClassOrStructSafeDecodingMacrosTests {
                 }
 
                 extension Model {
-                    private enum CodingKeys: CodingKey {
+                    private enum CodingKeys: String, CodingKey {
                     }
                     public init(from decoder: Decoder) throws {
                     }
@@ -620,7 +621,7 @@ extension ClassOrStructSafeDecodingMacrosTests {
                 }
 
                 extension Model {
-                    private enum CodingKeys: CodingKey {
+                    private enum CodingKeys: String, CodingKey {
                     }
                     open init(from decoder: Decoder) throws {
                     }
@@ -653,7 +654,7 @@ extension ClassOrStructSafeDecodingMacrosTests {
                 }
 
                 extension Model {
-                    private enum CodingKeys: CodingKey {
+                    private enum CodingKeys: String, CodingKey {
                         case int
                     }
                     init(from decoder: Decoder) throws {
@@ -661,8 +662,7 @@ extension ClassOrStructSafeDecodingMacrosTests {
                         do {
                             self.int = try container.decode(Int.self, forKey: .int)
                         } catch {
-                            if let retry = (try? container.decode(String.self, forKey: .int)).flatMap({
-                                    Int.init($0, radix: 10)
+                            if let retry = (try? container.decode(String.self, forKey: .int)).flatMap({ Int.init($0, radix: 10)
                                 }) {
                                 self.int = retry
                                 SafeDecodingErrorReporter.shared.report(error: error, of: "int", decoding: Int.self, in: (Model).self)
@@ -698,7 +698,7 @@ extension ClassOrStructSafeDecodingMacrosTests {
                 }
 
                 extension Model {
-                    private enum CodingKeys: CodingKey {
+                    private enum CodingKeys: String, CodingKey {
                         case int
                     }
                     init(from decoder: Decoder) throws {
@@ -744,7 +744,7 @@ extension ClassOrStructSafeDecodingMacrosTests {
                 }
 
                 extension Model {
-                    private enum CodingKeys: CodingKey {
+                    private enum CodingKeys: String, CodingKey {
                         case int
                         case optionalInt
                     }
@@ -770,6 +770,44 @@ extension ClassOrStructSafeDecodingMacrosTests {
 #endif
     }
 }
+
+extension ClassOrStructSafeDecodingMacrosTests {
+    func testSafeDecodingPropertyNameDecoding() throws {
+#if canImport(SafeDecodingMacros)
+        // @FallbackDecoding will be ignored for "int" property as it is non-optional
+        assertMacroExpansion(
+                """
+                @ClassOrStructSafeDecoding
+                struct Model {
+                    @PropertyNameDecoding("override-name")
+                    let property: Int
+                }
+                """,
+                expandedSource:
+                """
+
+                struct Model {
+                    let property: Int
+                }
+
+                extension Model {
+                    private enum CodingKeys: String, CodingKey {
+                        case property = "override-name"
+                    }
+                    init(from decoder: Decoder) throws {
+                        let container = try decoder.container(keyedBy: CodingKeys.self)
+                        self.property = try container.decode(Int.self, forKey: .property)
+                    }
+                }
+                """,
+                macros: testMacros
+        )
+#else
+        throw XCTSkip("macros are only supported when running tests for the host platform")
+#endif
+    }
+}
+
 
 extension ClassOrStructSafeDecodingMacrosTests {
     func testMacro() throws {
@@ -802,7 +840,7 @@ extension ClassOrStructSafeDecodingMacrosTests {
             }
 
             extension Custom {
-                private enum CodingKeys: CodingKey {
+                private enum CodingKeys: String, CodingKey {
                     case integer
                     case optional
                     case array
@@ -813,7 +851,7 @@ extension ClassOrStructSafeDecodingMacrosTests {
                 public init(from decoder: Decoder) throws {
                     let container = try decoder.container(keyedBy: CodingKeys.self)
                     self.integer = try container.decode(Int .self, forKey: .integer)
-                    self.optional = try? container.decode(Int.self, forKey: .optional)
+                    self.optional = (try? container.decode(Int.self, forKey: .optional))
                     self.array = try container.decode([Int].self, forKey: .array)
                     self.genericArray = ((try? container.decode([SafeDecodable<Int>].self, forKey: .genericArray)) ?? []).compactMap {
                         $0.decoded


### PR DESCRIPTION
- Bump swift-sintax >= 601.0.0
- Added PropertyNameDecodingMacro
- Exposed @PropertyNameDecoding macro
- Covered property name override in class/struct/actor safe decoding
- Updated (removed deprecated) uses of ".as(...)"
- Minor tweaks in main.swift
- Update tests to cover property name override and reflect code output changes