### PR TITLE
Add coding key casing via enumeration

### DIFF
--- a/Sources/SafeDecoding/Macros/Macros/Attached/Model/PropertyNameCasingStrategy.swift
+++ b/Sources/SafeDecoding/Macros/Macros/Attached/Model/PropertyNameCasingStrategy.swift
@@ -1,0 +1,32 @@
+enum PropertyNameCasingStrategy: String {
+    case camel
+    case snake
+    case snakeUppercase
+    case kebab
+    case kebabUppercase
+    case flat
+}
+
+extension PropertyNameCasingStrategy {
+    func casing(_ string: String) -> String {
+        switch self {
+        case .camel:
+            string.camelCased
+
+        case .snake:
+            string.snakeCased
+
+        case .snakeUppercase:
+            string.snakeUppercased
+
+        case .kebab:
+            string.kebabCased
+
+        case .kebabUppercase:
+            string.kebabUppercased
+
+        case .flat:
+            string.flat
+        }
+    }
+}

--- a/Sources/SafeDecoding/Macros/Macros/Utils/StringExtensions.swift
+++ b/Sources/SafeDecoding/Macros/Macros/Utils/StringExtensions.swift
@@ -1,0 +1,78 @@
+import Foundation
+
+extension String {
+    func camelCased(capitalizeFirstSegment: Bool = false) -> String {
+        guard !isEmpty else { return "" }
+
+        let output = components(separatedBy: .alphanumerics.inverted)
+            .enumerated()
+            .map { offset, element in
+                if capitalizeFirstSegment || offset > .zero {
+                    return element.prefix(1).capitalized + element.dropFirst()
+                } else {
+                    return element
+                }
+            }
+            .joined()
+
+        return output
+    }
+
+    var camelCased: String {
+        camelCased()
+    }
+
+    var snakeCased: String {
+        guard !isEmpty else { return self }
+
+        let step1 = camelCased.replacing(
+            #/([A-Z]+)([A-Z][a-z])/#
+        ) { match in
+            return "\(match.output.1)_\(match.output.2)"
+        }
+
+        let step2 = step1.replacing(
+            #/([a-z0-9])([A-Z]|[^A-Za-z0-9])/#
+        ) { match in
+            let left = String(match.output.1)
+            let right = String(match.output.2)
+
+            if right.unicodeScalars.allSatisfy({ !CharacterSet.alphanumerics.contains($0) }) {
+                return "\(left)_"
+            } else {
+                return "\(left)_\(right)"
+            }
+        }
+
+        let output = step2
+            .lowercased()
+            .replacing(#/_+/#, with: "_")
+            .trimmingCharacters(in: CharacterSet(charactersIn: "_"))
+
+        return output
+    }
+
+    var snakeUppercased: String {
+        snakeCased.uppercased()
+    }
+
+    var kebabCased: String {
+        snakeCased
+            .replacingOccurrences(
+                of: "_",
+                with: "-"
+            )
+    }
+
+    var kebabUppercased: String {
+        kebabCased.uppercased()
+    }
+
+    var flat: String {
+        replacingOccurrences(
+            of: "_-",
+            with: ""
+        )
+        .lowercased()
+    }
+}

--- a/Sources/SafeDecoding/PlugIn/Model/PropertyNameCasingStrategy.swift
+++ b/Sources/SafeDecoding/PlugIn/Model/PropertyNameCasingStrategy.swift
@@ -1,0 +1,8 @@
+public enum PropertyNameCasingStrategy {
+    case camel
+    case snake
+    case snakeUppercase
+    case kebab
+    case kebabUpercase
+    case flat
+}

--- a/Sources/SafeDecoding/PlugIn/PropertyNameDecoding.swift
+++ b/Sources/SafeDecoding/PlugIn/PropertyNameDecoding.swift
@@ -3,3 +3,9 @@ public macro PropertyNameDecoding(_: StaticString) = #externalMacro(
     module: "SafeDecodingMacros",
     type: "PropertyNameDecodingMacro"
 )
+
+@attached(peer)
+public macro PropertyNameDecoding(casing: PropertyNameCasingStrategy) = #externalMacro(
+    module: "SafeDecodingMacros",
+    type: "PropertyNameDecodingMacro"
+)

--- a/Tests/SafeDecodingMacrosTests/ClassOrStructSafeDecodingMacrosTests.swift
+++ b/Tests/SafeDecodingMacrosTests/ClassOrStructSafeDecodingMacrosTests.swift
@@ -781,6 +781,18 @@ extension ClassOrStructSafeDecodingMacrosTests {
                 struct Model {
                     @PropertyNameDecoding("override-name")
                     let property: Int
+                    @PropertyNameDecoding(casing: .camel)
+                    let intPropertyCamel: Int
+                    @PropertyNameDecoding(casing: .snake)
+                    let intPropertySnake: Int
+                    @PropertyNameDecoding(casing: .snakeUppercase)
+                    let intPropertySnakeUppercase: Int
+                    @PropertyNameDecoding(casing: .kebab)
+                    let intPropertyKebab: Int
+                    @PropertyNameDecoding(casing: .kebabUppercase)
+                    let intPropertyKebabUppercase: Int
+                    @PropertyNameDecoding(casing: .flat)
+                    let intPropertyFlat: Int
                 }
                 """,
                 expandedSource:
@@ -788,15 +800,33 @@ extension ClassOrStructSafeDecodingMacrosTests {
 
                 struct Model {
                     let property: Int
+                    let intPropertyCamel: Int
+                    let intPropertySnake: Int
+                    let intPropertySnakeUppercase: Int
+                    let intPropertyKebab: Int
+                    let intPropertyKebabUppercase: Int
+                    let intPropertyFlat: Int
                 }
 
                 extension Model {
                     private enum CodingKeys: String, CodingKey {
                         case property = "override-name"
+                        case intPropertyCamel = "intPropertyCamel"
+                        case intPropertySnake = "int_property_snake"
+                        case intPropertySnakeUppercase = "INT_PROPERTY_SNAKE_UPPERCASE"
+                        case intPropertyKebab = "int-property-kebab"
+                        case intPropertyKebabUppercase = "INT-PROPERTY-KEBAB-UPPERCASE"
+                        case intPropertyFlat = "intpropertyflat"
                     }
                     init(from decoder: Decoder) throws {
                         let container = try decoder.container(keyedBy: CodingKeys.self)
                         self.property = try container.decode(Int.self, forKey: .property)
+                        self.intPropertyCamel = try container.decode(Int.self, forKey: .intPropertyCamel)
+                        self.intPropertySnake = try container.decode(Int.self, forKey: .intPropertySnake)
+                        self.intPropertySnakeUppercase = try container.decode(Int.self, forKey: .intPropertySnakeUppercase)
+                        self.intPropertyKebab = try container.decode(Int.self, forKey: .intPropertyKebab)
+                        self.intPropertyKebabUppercase = try container.decode(Int.self, forKey: .intPropertyKebabUppercase)
+                        self.intPropertyFlat = try container.decode(Int.self, forKey: .intPropertyFlat)
                     }
                 }
                 """,

--- a/Tests/SafeDecodingTests/StringExtensionsTests.swift
+++ b/Tests/SafeDecodingTests/StringExtensionsTests.swift
@@ -1,0 +1,60 @@
+import Foundation
+@testable import SafeDecodingMacros
+import Testing
+
+struct StringExtensionsTests {
+    @Test(
+        "Test camel casing conversion",
+        arguments: zip(
+            ["HTTPClient", "httpClient", "userId", "user_id", "user-id", "user id"],
+            ["HTTPClient", "httpClient", "userId", "userId", "userId", "userId"]
+        )
+    )
+    func testCamelCasing(input: String, output: String) throws {
+        #expect(input.camelCased == output)
+    }
+
+    @Test(
+        "Test snake casing conversion",
+        arguments: zip(
+            ["HTTPClient", "httpClient", "userId", "user_id", "user-id", "user id"],
+            ["http_client", "http_client", "user_id", "user_id", "user_id", "user_id"]
+        )
+    )
+    func testSnakeCasing(input: String, output: String) throws {
+        #expect(input.snakeCased == output)
+    }
+
+    @Test(
+        "Test snake uppercase casing conversion",
+        arguments: zip(
+            ["HTTPClient", "httpClient", "userId", "user_id", "user-id", "user id"],
+            ["HTTP_CLIENT", "HTTP_CLIENT", "USER_ID", "USER_ID", "USER_ID", "USER_ID"]
+        )
+    )
+    func testSnakeUppercaseCasing(input: String, output: String) throws {
+        #expect(input.snakeUppercased == output)
+    }
+
+    @Test(
+        "Test snake casing conversion",
+        arguments: zip(
+            ["HTTPClient", "httpClient", "userId", "user_id", "user-id", "user id"],
+            ["http-client", "http-client", "user-id", "user-id", "user-id", "user-id"]
+        )
+    )
+    func testKebabCasing(input: String, output: String) throws {
+        #expect(input.kebabCased == output)
+    }
+
+    @Test(
+        "Test snake casing conversion",
+        arguments: zip(
+            ["HTTPClient", "httpClient", "userId", "user_id", "user-id", "user id"],
+            ["HTTP-CLIENT", "HTTP-CLIENT", "USER-ID", "USER-ID", "USER-ID", "USER-ID"]
+        )
+    )
+    func testKebabUppercaseCasing(input: String, output: String) throws {
+        #expect(input.kebabUppercased == output)
+    }
+}


### PR DESCRIPTION
- Add internal String extension for common casing strategies and tests
- Add PropertyNameCasingStrategy (macro-internal and public facing API)
- Update ClassOrStructSafeDecodingMacro to use enumerated casing strategies
- Expose @PropertyNameDecoding(casing:)
- Update tests for all coding key naming strategies