### PR TITLE
Fix PropertyNameCasingStrategy case name

### DIFF
--- a/Sources/SafeDecoding/ExampleClient/main.swift
+++ b/Sources/SafeDecoding/ExampleClient/main.swift
@@ -92,7 +92,9 @@ struct ModelFullExample {
     @RetryDecoding(Double.self, map: { Int($0) })
     let integer: Int
     @IgnoreSafeDecoding
+    @PropertyNameDecoding(casing: .snake)
     let integerArray: [Int]
+    @PropertyNameDecoding(casing: .kebabUppercase)
     let genericArray: Array<String>
     @FallbackDecoding(UUID().uuidString)
     let string: String

--- a/Sources/SafeDecoding/PlugIn/Model/PropertyNameCasingStrategy.swift
+++ b/Sources/SafeDecoding/PlugIn/Model/PropertyNameCasingStrategy.swift
@@ -3,6 +3,6 @@ public enum PropertyNameCasingStrategy {
     case snake
     case snakeUppercase
     case kebab
-    case kebabUpercase
+    case kebabUppercase
     case flat
 }


### PR DESCRIPTION
- Rename .kebabUpercase to .kebabUppercase
- Add examples to main.swift