### PR TITLE
Handle enums with no associated values

### DIFF
--- a/Sources/SafeDecoding/Macros/Macros/Peers/CaseNameDecodingMacro.swift
+++ b/Sources/SafeDecoding/Macros/Macros/Peers/CaseNameDecodingMacro.swift
@@ -1,8 +1,8 @@
 import SwiftSyntax
 import SwiftSyntaxMacros
 
-enum CaseNameDecodingMacro: PeerMacro {
-    static func expansion(
+public enum CaseNameDecodingMacro: PeerMacro {
+    public static func expansion(
         of node: AttributeSyntax,
         providingPeersOf declaration: some DeclSyntaxProtocol,
         in context: some MacroExpansionContext

--- a/Sources/SafeDecoding/Macros/Macros/Utils/EquatableExtensions.swift
+++ b/Sources/SafeDecoding/Macros/Macros/Utils/EquatableExtensions.swift
@@ -1,0 +1,11 @@
+import Foundation
+
+extension Equatable {
+    func `in`(_ collection: some Collection<Self>) -> Bool {
+        collection.contains(self)
+    }
+
+    func `in`(_ collection: Self ...) -> Bool {
+        self.in(collection)
+    }
+}

--- a/Sources/SafeDecoding/PlugIn/Model/EnumCaseDecodingStrategy.swift
+++ b/Sources/SafeDecoding/PlugIn/Model/EnumCaseDecodingStrategy.swift
@@ -10,6 +10,74 @@ public enum EnumCaseDecodingStrategy {
      For some enum:
 
      ```
+     @SafeDecoding(decodingStrategy: .natural)
+     enum Chirality {
+        case left
+        @CaseNameDecoding("rght")
+        case right
+     }
+     ```
+
+     Expects a JSON payload that either matches:
+     - the raw value associated with the case, if one is provided
+     - the raw string matching the readable case name
+     - the name provided by ``CaseNameDecoding``, as a raw string
+
+     ```
+     "left"
+     ```
+
+     Will be decoded into `Chirality.left`.
+
+     ```
+     "rght"
+     ```
+
+     Will be decoded into `Chirality.right`.
+
+     ```
+     "right"
+     ```
+
+     Will fail decoding.
+
+     If the enumeration is `RawRepresentable`,
+     A single value matching the `Chirality.RawValue` will be
+     decoded and matched against each of the `case`'s `.rawValue`s.
+     If `Chirality` is `RawRepresentable`:
+
+     ```
+     @SafeDecodable(decodingStrategy: .natural)
+     enum Chirality: Int {
+        case left
+        case right
+     }
+     ```
+
+     Then decoding will always take place matching decoded value against each case's `.rawValue`:
+
+     ```
+     init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        let rawValue = try container.decode(Self.RawValue.self)
+
+        switch rawValue {
+            case Self.left.rawValue:
+                self = .left
+            case Self.right.rawValue:
+                self = .right
+            default:
+                throw ...
+        }
+     }
+     ```
+     */
+    case natural
+
+    /**
+     For some enum:
+
+     ```
      @SafeDecoding(decodingStrategy: .caseByObjectProperty("type"))
      enum Sample {
         case one(id: String, title: String, ...)


### PR DESCRIPTION
- Add EnumCaseDecodingStrategy.natural
- Handle natural decoding in EnumSafeDecodingMacro
- Diagnose error when using EnumCaseDecodingStrategy.natural on enumerations where some case(s) have properties
- Diagnose warning when using EnumCaseDecodingStrategy.natural and specifying a reporter
- Add examples in main
- Update tests